### PR TITLE
Commodel

### DIFF
--- a/Mosey/Models/ImagingDevice.cs
+++ b/Mosey/Models/ImagingDevice.cs
@@ -29,7 +29,6 @@ namespace Mosey.Models
         void GetImage();
         void SaveImage();
         IEnumerable<string> SaveImage(string fileName, string directory, string fileFormat);
-        Exception ErrorState { get; }
     }
 
     public interface IImagingDeviceSettings

--- a/Mosey/Models/ImagingDevice.cs
+++ b/Mosey/Models/ImagingDevice.cs
@@ -18,7 +18,7 @@ namespace Mosey.Models
         IEnumerable<T> GetByEnabled(bool enabled);
     }
 
-    public interface IImagingDevice : IEquatable<IImagingDevice>, INotifyPropertyChanged, IDisposable
+    public interface IImagingDevice : IEquatable<IImagingDevice>, INotifyPropertyChanged
     {
         string Name { get; }
         int ID { get; }

--- a/Mosey/Services/ScanningDevice.cs
+++ b/Mosey/Services/ScanningDevice.cs
@@ -349,22 +349,14 @@ namespace Mosey.Services
                 {
                     // Wait until the scanner is ready if it is warming up, busy etc
                     // Also retry if the WIA driver does not respond in time (NullReference)
-                    if (ex is NullReferenceException | ex.HResult == -2145320954 | ex.HResult == -2145320953 | ex.HResult == -2145320946 | ex.HResult == -2147467261)
-                    {
-                        System.Threading.Thread.Sleep(1000);
-                        retryCount += 1;
-                        continue;
-                    }
-
-                    // Store error state if not attempting a retry
-                    if (ex is COMException)
-                    {
-                        ErrorState = new COMException(WiaExceptionExtensions.GetComErrorMessage((COMException)ex), ex);
-                    }
-                    else
-                    {
-                        ErrorState = ex;
-                    }
+                    System.Threading.Thread.Sleep(1000);
+                    retryCount += 1;
+                    continue;
+                }
+                catch (Exception ex)
+                {
+                    // Store error state on general error
+                    ErrorState = ex;
                     break;
                 }
                 finally

--- a/Mosey/Services/ScanningDevice.cs
+++ b/Mosey/Services/ScanningDevice.cs
@@ -316,6 +316,8 @@ namespace Mosey.Services
             {
                 try
                 {
+                    IsScanning = true;
+
                     // Connect to the specified device and create a COM object representation
                     using (ScannerDevice scannerDevice = new ScannerDevice(_scannerSettings))
                     {
@@ -332,7 +334,6 @@ namespace Mosey.Services
                         _images = new List<byte[]>();
 
                         // Retrieve image(s) from scanner
-                        IsScanning = true;
                         scannerDevice.PerformScan(format);
 
                         // Store images for processing etc

--- a/Mosey/ViewModels/MainViewModel.cs
+++ b/Mosey/ViewModels/MainViewModel.cs
@@ -439,11 +439,6 @@ namespace Mosey.ViewModels
 
                         // Run the scanner and retrieve the image(s) to memory
                         scanner.GetImage();
-                        if(scanner.ErrorState != null)
-                        {
-                            _log.LogError(scanner.ErrorState, $"Unable to retrieve image on {scanner.Name} (#{scannerIDStr}) at {saveDateTime}");
-                            continue;
-                        }
                         _log.LogDebug($"Retrieved image on {scanner.Name} (#{scannerIDStr}) at {saveDateTime}");
 
                         string fileName = String.Join("_", _imageConfig.Prefix, saveDateTime);

--- a/Mosey/Views/MainWindow.xaml
+++ b/Mosey/Views/MainWindow.xaml
@@ -165,7 +165,6 @@
                                 <TextBlock Text="{Binding ID}" Grid.Column="0" Grid.Row="1" />
                                 <TextBlock Text="Connected" Visibility="{Binding IsConnected, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Column="1" Grid.Row="1" />
                                 <Controls:ToggleSwitchButton Content="Enable scanning" IsChecked="{Binding Path=IsEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding IsScanning, Converter={Converters:BoolToInvertedBoolConverter}}" Cursor="Hand" Grid.Column="2" Grid.Row="1" />
-                                <TextBlock Text="{Binding ErrorState.Message}" Grid.Column="2" Grid.Row="1" />
                                 <Label Visibility="{Binding IsScanning, Converter={StaticResource BooleanToVisibilityConverter}}" Style="{StaticResource IconNormal}" Grid.Column="4" Grid.RowSpan="2">
                                     <IconPacks:Material Kind="DotsHorizontalCircle" Spin="True" SpinDuration="3.5" Height="40" Width="40" />
                                 </Label>


### PR DESCRIPTION
Replace the existing method of holding references to COM objects. Instead, a reference to the required device is stored and the COM object is requested from the WIA device manager as required