### PR TITLE
Ensure correct image encoding

### DIFF
--- a/Mosey/Mosey.csproj
+++ b/Mosey/Mosey.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.3" />
     <PackageReference Include="NReco.Logging.File" Version="1.0.5" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0-preview.4.20251.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mosey/Services/Imaging/Extensions/ImageByteExtensions.cs
+++ b/Mosey/Services/Imaging/Extensions/ImageByteExtensions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Mosey.Services.Imaging.Extensions
+{
+    /// <summary>
+    /// Extension methods for images stored as <see cref="byte"/> arrays
+    /// </summary>
+    public static class ImageByteExtensions
+    {
+        private static readonly ImageConverter _imageConverter = new ImageConverter();
+
+        /// <summary>
+        /// Convert an image <see cref="byte"/> array to a specified format and encoding.
+        /// </summary>
+        /// <param name="value">An image as a byte array</param>
+        /// <param name="format">The format for the image</param>
+        /// <param name="encoderParameters">A collection of <see cref="EncoderParameter"/>s to set image quality, colour depth etc</param>
+        /// <returns>An image <see cref="byte"/> array in the specified format and encoding</returns>
+        public static byte[] AsFormat(this byte[] value, ImageFormat format, EncoderParameters encoderParameters = null)
+        {
+            return value.ToImage().ToBytes(format, encoderParameters);
+        }
+
+        /// <summary>
+        /// Create an <see cref="Image"/> instance from an image <see cref="byte"/> array.
+        /// </summary>
+        /// <param name="value">An image as a <see cref="byte"/> array</param>
+        /// <returns>An <see cref="Image"/> instance</returns>
+        public static Image ToImage(this byte[] value)
+        {
+            return (Image)_imageConverter.ConvertFrom(value);
+        }
+
+        /// <summary>
+        /// Create an <see cref="Image"/> instance from an image <see cref="byte"/> array.
+        /// </summary>
+        /// <param name="value">An image as a <see cref="byte"/> array</param>
+        /// <param name="format">The image format</param>
+        /// <returns>An <see cref="Image"/> instance in the specified format</returns>
+        public static Image ToImage(this byte[] value, ImageFormat format)
+        {
+            return value.ToImage(format);
+        }
+
+        /// <summary>
+        /// Create an <see cref="Image"/> instance from an image <see cref="byte"/> array.
+        /// </summary>
+        /// <param name="value">An image as a byte array</param>
+        /// <param name="format">The format for the image</param>
+        /// <param name="encoderParameters">A collection of <see cref="EncoderParameter"/>s to set image quality, colour depth etc</param>
+        /// <returns>An <see cref="Image"/> instance in the specified format and encoding</returns>
+        public static Image ToImage(this byte[] value, ImageFormat format, EncoderParameters encoderParameters = null)
+        {
+            using (var ms = value.ToImage().ToMemoryStream(format, encoderParameters))
+            {
+                return Image.FromStream(ms);
+            }
+        }
+    }
+}

--- a/Mosey/Services/Imaging/Extensions/ImageExtensions.cs
+++ b/Mosey/Services/Imaging/Extensions/ImageExtensions.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Linq;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Mosey.Services.Imaging.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="Image"/> instances and related classes.
+    /// </summary>
+    public static class ImageExtensions
+    {
+        /// <summary>
+        /// Convert an <see cref="Image"/> instance to a specified format and encoding.
+        /// </summary>
+        /// <param name="value">An <see cref="Image"/> instance</param>
+        /// <param name="format">The format for the image</param>
+        /// <param name="encoderParameters">A collection of <see cref="EncoderParameter"/>s to set image quality, colour depth etc</param>
+        /// <returns>An <see cref="Image"/> instance in the specified format and encoding</returns>
+        public static Image AsFormat(this Image value, ImageFormat format, EncoderParameters encoderParameters = null)
+        {
+            using (var ms = value.ToMemoryStream(format, encoderParameters))
+            {
+                return Image.FromStream(ms);
+            }
+        }
+
+        /// <summary>
+        /// Create a <see cref="byte"/> array from an <see cref="Image"/> instance.
+        /// </summary>
+        /// <param name="value">An <see cref="Image"/> instance</param>
+        /// <returns>A <see cref="byte"/> array</returns>
+        public static byte[] ToBytes(this Image value)
+        {
+            return value.ToBytes(value.RawFormat);
+        }
+
+        /// <summary>
+        /// Create a <see cref="byte"/> array from an <see cref="Image"/> instance.
+        /// </summary>
+        /// <param name="value">An <see cref="Image"/> instance</param>
+        /// <param name="format">The image format</param>
+        /// <returns>An image <see cref="byte"/> array in the specified format</returns>
+        public static byte[] ToBytes(this Image value, ImageFormat format)
+        {
+            return value.ToBytes(format);
+        }
+
+        /// <summary>
+        /// Create a <see cref="byte"/> array from an <see cref="Image"/> instance.
+        /// </summary>
+        /// <param name="value">An <see cref="Image"/> instance</param>
+        /// <param name="format">The image format</param>
+        /// <param name="encoderParameters">A collection of <see cref="EncoderParameter"/>s to set image quality, colour depth etc</param>
+        /// <returns>An image <see cref="byte"/> array in the specified format and encoding</returns>
+        public static byte[] ToBytes(this Image value, ImageFormat format, EncoderParameters encoderParameters = null)
+        {
+            using (var ms = value.ToMemoryStream(format, encoderParameters))
+            {
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Find the <see cref="ImageCodecInfo"/> for an <see cref="ImageFormat"/> instance.
+        /// </summary>
+        /// <param name="value">An image format instance</param>
+        /// <returns>An <see cref="ImageCodecInfo"/> instance corresponding to the <see cref="ImageFormat"/></returns>
+        public static ImageCodecInfo CodecInfo(this ImageFormat value)
+        {
+            return ImageCodecInfo.GetImageDecoders().First(codec => codec.FormatID == value.Guid);
+        }
+
+        /// <summary>
+        /// Add optional <see cref="EncoderParameter"/>s to a <see cref="EncoderParameters"/> collection.
+        /// </summary>
+        /// <param name="value">An <see cref="EncoderParameters"/> collection</param>
+        /// <param name="compression">The algorithm used for compressing the image</param>
+        /// <param name="quality">Expressed as a percentage, with 100 being original image quality</param>
+        /// <param name="colorDepth">Colour range in bits per pixel</param>
+        /// <param name="transform">A TransformFlip or TransformRotate <see cref="EncoderValue"/></param>
+        /// <param name="frame">Specifies that the image has more than one frame (page). Can be passed to the TIFF encoder</param>
+        /// <returns>A <see cref="EncoderParameters"/> collection containing the specified <see cref="EncoderParameter"/>s</returns>
+        public static EncoderParameters AddParams(this EncoderParameters value, EncoderValue? compression = null, long? quality = null, long? colorDepth = null, EncoderValue? transform = null, EncoderValue? frame = null)
+        {
+            if (quality < 0 || quality > 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quality), quality.Value, $"{nameof(quality)} is a percentage and must be between 0 and 100");
+            }
+            if (colorDepth <= 0 || colorDepth > 48)
+            {
+                throw new ArgumentOutOfRangeException(nameof(colorDepth), colorDepth.Value, $"{nameof(colorDepth)} out of range");
+            }
+
+            // Replace existing values in the paramter list if they already exist
+            // Otherwise just add them to the collection
+            var encoderParams = value.Param.Where(e => e != null).ToList();
+            if (compression != null) encoderParams.AddOrUpdate(new EncoderParameter(Encoder.Compression, (long)compression));
+            if (quality != null) encoderParams.AddOrUpdate(new EncoderParameter(Encoder.Quality, (long)quality));
+            if (colorDepth != null) encoderParams.AddOrUpdate(new EncoderParameter(Encoder.ColorDepth, (long)colorDepth));
+            if (transform != null) encoderParams.AddOrUpdate(new EncoderParameter(Encoder.Transformation, (long)transform));
+            if (frame != null) encoderParams.AddOrUpdate(new EncoderParameter(Encoder.SaveFlag, (long)frame));
+
+            // Unfortunately the parameters can't be appended to the original collection directly
+            // Create a new collection now that we know the total array size
+            var paramCollection = new EncoderParameters(encoderParams.Count);
+            for (int i = 0; i < encoderParams.Count; i++)
+            {
+                paramCollection.Param[i] = encoderParams[i];
+            }
+
+            // Clear up the original collection
+            value?.Dispose();
+
+            return paramCollection;
+        }
+    }
+}

--- a/Mosey/Services/Imaging/Extensions/ImageFormatExtensions.cs
+++ b/Mosey/Services/Imaging/Extensions/ImageFormatExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Drawing.Imaging;
+
+namespace Mosey.Services.Imaging.Extensions
+{
+    public static class ImageFormatExtensions
+    {
+        /// <summary>
+        /// Convert a file extension string to an <see cref="ScanningDevice.ImageFormat"/> <see cref="Enum"/>.
+        /// </summary>
+        /// <param name="value">An <see cref="ScanningDevice.ImageFormat"/> instance</param>
+        /// <param name="imageFormatStr">A file extension <see cref="string"/></param>
+        /// <returns>An <see cref="ScanningDevice.ImageFormat"/> <see cref="Enum"/></returns>
+        public static ScanningDevice.ImageFormat FromString(this ScanningDevice.ImageFormat value, string imageFormatStr)
+        {
+            if (Enum.TryParse(imageFormatStr, ignoreCase: true, out value))
+            {
+                return value;
+            }
+            else
+            {
+                throw new ArgumentException($"{imageFormatStr} is not a supported image file extension.");
+            }
+        }
+
+        /// <summary>
+        /// Convert to a <see cref="ImageFormat"/> instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>A <see cref="ImageFormat"/> instance</returns>
+        public static ImageFormat ToDrawingImageFormat(this ScanningDevice.ImageFormat value)
+        {
+            return (ImageFormat)typeof(ImageFormat)
+                    .GetProperty(value.ToString(), System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.IgnoreCase)
+                    .GetValue(null);
+        }
+    }
+}

--- a/Mosey/Services/Imaging/Extensions/Utilities.cs
+++ b/Mosey/Services/Imaging/Extensions/Utilities.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Mosey.Services.Imaging.Extensions
+{
+    internal static class Utilities
+    {
+        /// <summary>
+        /// Add an <see cref="EncoderParameter"/> to a list, or update the existing value if already present
+        /// </summary>
+        /// <param name="value">A list of <see cref="EncoderParameter"/>s</param>
+        /// <param name="encoderParameter">An <see cref="EncoderParameter"/> instance to add or update</param>
+        /// <returns>A list where the <see cref="EncoderParameter"/> has either replaced an existing value or been appended</returns>
+        internal static List<EncoderParameter> AddOrUpdate(this List<EncoderParameter> value, EncoderParameter encoderParameter)
+        {
+            // Check if the encoder is already present in the list
+            int paramIndex = value.FindIndex(e => e != null && e.Encoder == encoderParameter.Encoder);
+            if (paramIndex >= 0)
+            {
+                // Update the existing value
+                value[paramIndex]?.Dispose();
+                value[paramIndex] = encoderParameter;
+            }
+            else
+            {
+                // Otherwise add it to the list
+                value.Add(encoderParameter);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Create a <see cref="MemoryStream"/> from an <see cref="Image"/> instance.
+        /// The <see cref="Image"/> is converted to the specified format and encoding.
+        /// </summary>
+        /// <param name="value">An <see cref="Image"/> instance</param>
+        /// <param name="format">The format for the image</param>
+        /// <param name="encoderParameters">A collection of <see cref="EncoderParameter"/>s to set image quality, colour depth etc</param>
+        /// <returns>An <see cref="Image"/> <see cref="MemoryStream"/> in the specified format and encoding</returns>
+        internal static MemoryStream ToMemoryStream(this Image value, ImageFormat format, EncoderParameters encoderParameters = null)
+        {
+            using (var ms = new MemoryStream())
+            {
+                value.Save(ms, format.CodecInfo(), encoderParameters);
+
+                return ms;
+            }
+        }
+    }
+}

--- a/Mosey/Services/ScanningDevice.cs
+++ b/Mosey/Services/ScanningDevice.cs
@@ -653,37 +653,4 @@ namespace Mosey.Services
             return MemberwiseClone();
         }
     }
-
-    public static class ImageFormatExtensions
-    {
-        /// <summary>
-        /// Convert a file extension string to an <see cref="ScanningDevice.ImageFormat"/> <see cref="Enum"/>.
-        /// </summary>
-        /// <param name="value">An <see cref="ScanningDevice.ImageFormat"/> instance</param>
-        /// <param name="imageFormatStr">A file extension <see cref="string"/></param>
-        /// <returns>An <see cref="ScanningDevice.ImageFormat"/> <see cref="Enum"/></returns>
-        public static ScanningDevice.ImageFormat FromString(this ScanningDevice.ImageFormat value, string imageFormatStr)
-        {
-            if (Enum.TryParse(imageFormatStr, ignoreCase: true, out value))
-            {
-                return value;
-            }
-            else
-            {
-                throw new ArgumentException($"{imageFormatStr} is not a supported image file extension.");
-            }
-        }
-
-        /// <summary>
-        /// Convert to a <see cref="System.Drawing.Imaging.ImageFormat"/> instance.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns>A <see cref="System.Drawing.Imaging.ImageFormat"/> instance</returns>
-        public static System.Drawing.Imaging.ImageFormat ToDrawingImageFormat(this ScanningDevice.ImageFormat value)
-        {
-            return (System.Drawing.Imaging.ImageFormat)typeof(System.Drawing.Imaging.ImageFormat)
-                    .GetProperty(value.ToString(), System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.IgnoreCase)
-                    .GetValue(null);
-        }
-    }
 }

--- a/Mosey/Services/ScanningDevice.cs
+++ b/Mosey/Services/ScanningDevice.cs
@@ -536,7 +536,7 @@ namespace Mosey.Services
             using (EncoderParameters encoderParameters = new EncoderParameters().AddParams(
                 compression: EncoderValue.CompressionLZW,
                 quality: 100,
-                colorDepth: 32
+                colorDepth: 24
                 ))
             {
                 // Write all images to disk


### PR DESCRIPTION
Images are currently saved with TIFF file extensions but retain their original BMP encoding.

- Ensure images are saved to disk with correct encoding
- Add extension methods for easier conversion between image byte arrays and Image instances
- Convert image byte arrays to a format other than BMP to reduce memory overhead